### PR TITLE
added eager loading of lines and addresses to account orders api

### DIFF
--- a/src/budy/controllers/api/account.py
+++ b/src/budy/controllers/api/account.py
@@ -68,11 +68,7 @@ class AccountApiController(root.RootApiController):
         orders = budy.Order.find(
             account = account.id,
             paid = True,
-            eager = (
-                "lines",
-                "shipping_address",
-                "billing_address"
-            ),
+            eager = ("lines",),
             map = True,
             **object
         )

--- a/src/budy/controllers/api/account.py
+++ b/src/budy/controllers/api/account.py
@@ -68,6 +68,11 @@ class AccountApiController(root.RootApiController):
         orders = budy.Order.find(
             account = account.id,
             paid = True,
+            eager = (
+                "lines",
+                "shipping_address",
+                "billing_address"
+            ),
             map = True,
             **object
         )


### PR DESCRIPTION
Not sure if this is the way to go, but basically the appier wrap method is not counting with relations that aren't loaded, which causes all kinds of problems wrapping relations:

```python
    @classmethod
    def wrap(cls, models, build = True, handler = None, **kwargs):
        is_sequence = type(models) in (list, tuple)
        if not is_sequence: models = [models]
        wrapping = []
        for model in models:
            _model = cls(model = model, **kwargs)
            handler and handler(_model.model)
            build and cls.build(_model.model, map = False)
            wrapping.append(_model)
        if is_sequence: return wrapping
        else: return wrapping[0]
```